### PR TITLE
Fixed syntax for s3_resources list

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ module "s3_user" {
   stage        = "prod"
   name         = "app"
   s3_actions   = ["s3:GetObject"]
-  s3_resources = "arn:aws:s3:::examplebucket/*"
+  s3_resources = ["arn:aws:s3:::examplebucket/*"]
 }
 ```
 


### PR DESCRIPTION
Updated to be a list for s3_resources, otherwise, TF will return an error.

```
Error: Error asking for user input: 1 error(s) occurred:

* module.s3_user.var.s3_resources: variable s3_resources in module s3_user should be type list, got string
```